### PR TITLE
Add missing intro SwiftUI files

### DIFF
--- a/IntroPagesModel.swift
+++ b/IntroPagesModel.swift
@@ -1,0 +1,24 @@
+//
+//  IntroPagesModel.swift
+//  SchoolAssisstant
+//
+//  Created by OpenAI on 2025.
+//
+
+import Foundation
+
+struct IntroPage: Identifiable {
+    let id = UUID()
+    let title: String
+    let description: String
+    let systemImage: String
+}
+
+struct IntroPagesModel {
+    static let pages: [IntroPage] = [
+        IntroPage(title: "Welcome", description: "Manage your school tasks easily.", systemImage: "star"),
+        IntroPage(title: "Track Progress", description: "Keep track of what you've learned.", systemImage: "list.bullet.rectangle"),
+        IntroPage(title: "Stay Focused", description: "Use timers to stay productive.", systemImage: "timer")
+    ]
+}
+

--- a/IntroPagesView.swift
+++ b/IntroPagesView.swift
@@ -1,0 +1,49 @@
+//
+//  IntroPagesView.swift
+//  SchoolAssisstant
+//
+//  Created by OpenAI on 2025.
+//
+
+import SwiftUI
+
+struct IntroPagesView: View {
+    let pages = IntroPagesModel.pages
+    @Binding var showIntro: Bool
+
+    var body: some View {
+        VStack {
+            TabView {
+                ForEach(pages) { page in
+                    VStack(spacing: 16) {
+                        Image(systemName: page.systemImage)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 120, height: 120)
+                            .padding()
+
+                        Text(page.title)
+                            .font(.title)
+                            .fontWeight(.bold)
+
+                        Text(page.description)
+                            .font(.body)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal)
+                    }
+                }
+            }
+            .tabViewStyle(PageTabViewStyle())
+
+            Button("Continue") {
+                showIntro = false
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview {
+    IntroPagesView(showIntro: .constant(true))
+}
+

--- a/JobIntroView.swift
+++ b/JobIntroView.swift
@@ -1,0 +1,21 @@
+//
+//  JobIntroView.swift
+//  SchoolAssisstant
+//
+//  Created by OpenAI on 2025.
+//
+
+import SwiftUI
+
+struct JobIntroView: View {
+    @AppStorage("hasShownWelcome") private var hasShownWelcome: Bool = false
+
+    var body: some View {
+        IntroPagesView(showIntro: $hasShownWelcome)
+    }
+}
+
+#Preview {
+    JobIntroView()
+}
+


### PR DESCRIPTION
## Summary
- create `IntroPagesModel` with sample pages
- add `IntroPagesView` onboarding screen
- add `JobIntroView` to show the intro when launching the app

## Testing
- `swiftc IntroPagesModel.swift -o /tmp/model.out`
- `swiftc -emit-sil IntroPagesModel.swift IntroPagesView.swift JobIntroView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684579d43540832a9eeb6d2ad295608a