### PR TITLE
Remove FirebaseFirestoreSwift usage

### DIFF
--- a/LearningNote.swift
+++ b/LearningNote.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-import FirebaseFirestoreSwift
+import FirebaseFirestore
 
 struct LearningNote: Codable, Identifiable {
-    @DocumentID var id: String?
+    var id: String?
 
   let category: String
     let text: String
@@ -11,8 +11,6 @@ struct LearningNote: Codable, Identifiable {
     var reviewCount: Int
     var nextReview: Date
     let createdAt: Date
-/*
-
     init(id: String? = nil, category: String, text: String, importance: String, reviewCount: Int, nextReview: Date, createdAt: Date) {
         self.id = id
         self.category = category
@@ -51,5 +49,4 @@ struct LearningNote: Codable, Identifiable {
             "createdAt": Timestamp(date: createdAt)
         ]
     }
-*/
 }

--- a/NotesManager.swift
+++ b/NotesManager.swift
@@ -14,13 +14,13 @@ final class NotesManager {
     }
 
     func addNote(_ note: LearningNote, userId: String) async throws {
-        try notesCollection(userId: userId).addDocument(from: note)
+        try await notesCollection(userId: userId).addDocument(data: note.dictionary)
     }
 
     func fetchNotes(userId: String) async throws -> [LearningNote] {
         let snapshot = try await notesCollection(userId: userId).getDocuments()
-        return try snapshot.documents.compactMap { document in
-            try document.data(as: LearningNote.self)
+        return snapshot.documents.compactMap { document in
+            LearningNote(document: document)
         }
     }
 

--- a/StatsView.swift
+++ b/StatsView.swift
@@ -4,7 +4,7 @@ import FirebaseAuth
 import FirebaseFirestore
 
 struct StudySession: Identifiable, Codable {
-    @DocumentID var id: String?
+    var id: String?
     let session_start: Date
     let session_end: Date
     let studied_subject: String

--- a/TaskItem.swift
+++ b/TaskItem.swift
@@ -2,7 +2,7 @@ import Foundation
 import FirebaseFirestore
 
 struct TaskItem: Codable, Identifiable {
-    @DocumentID var id: String?
+    var id: String?
   
     var title: String
     var dueDate: Date

--- a/TaskManager.swift
+++ b/TaskManager.swift
@@ -14,22 +14,21 @@ final class TaskManager {
     }
 
     func addTask(_ task: TaskItem, userId: String) async throws {
-
-        try tasksCollection(userId: userId).addDocument(from: task)
+        try await tasksCollection(userId: userId).addDocument(data: task.dictionary)
     }
 
     func fetchTasks(userId: String) async throws -> [TaskItem] {
         let snapshot = try await tasksCollection(userId: userId).getDocuments()
 
-        return try snapshot.documents.compactMap { document in
-            try document.data(as: TaskItem.self)
+        return snapshot.documents.compactMap { document in
+            TaskItem(document: document)
         }
     }
 
     func updateTask(_ task: TaskItem, userId: String) async throws {
         guard let id = task.id else { return }
 
-        try tasksCollection(userId: userId).document(id).setData(from: task, merge: true)
+        try await tasksCollection(userId: userId).document(id).setData(task.dictionary, merge: true)
     }
 
     func deleteTask(_ id: String, userId: String) async throws {

--- a/UserManager.swift
+++ b/UserManager.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import FirebaseFirestore
-import FirebaseFirestoreSwift
 import PhotosUI
 import SwiftUI
 import Combine
@@ -222,8 +221,8 @@ final class UserManager: ObservableObject {
     func fetchStudySessions(userId: String) async throws -> [StudySession] {
         let snapshot = try await userDocument(userId: userId).collection("work_sessions").getDocuments()
 
-        return try snapshot.documents.compactMap { document in
-            try document.data(as: StudySession.self)
+        return snapshot.documents.compactMap { document in
+            StudySession(document: document)
         }
     }
     


### PR DESCRIPTION
## Summary
- switch Firestore imports from `FirebaseFirestoreSwift` to `FirebaseFirestore`
- remove `@DocumentID` usages and use manual decoding
- update Firestore managers to store and fetch dictionaries directly

## Testing
- `swiftc AddTaskView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6845e8d36e30832ab82dec3efd1a3129