### PR TITLE
Add study state prompt and spaced repetition reminders

### DIFF
--- a/HomeTab.swift
+++ b/HomeTab.swift
@@ -13,6 +13,7 @@ struct HomeTab: View {
     @StateObject private var notesViewModel = NotesViewModel()
     @StateObject private var statsModel = StatsViewModel()
     @Binding var selectedTab: Tab
+    @State private var showStudyState: Bool = false
 
 
     var body: some View {
@@ -91,10 +92,16 @@ struct HomeTab: View {
         .onAppear {
             Task {
                 try await viewModel.loadCurrentUser()
+                if viewModel.user?.studyState == nil {
+                    showStudyState = true
+                }
                 await notesViewModel.loadNotes()
                 await statsModel.load()
                 await viewModel.loadLeaderboard()
             }
+        }
+        .fullScreenCover(isPresented: $showStudyState) {
+            StudyStateView(show: $showStudyState)
         }
     }
 }

--- a/IntroPagesModel.swift
+++ b/IntroPagesModel.swift
@@ -16,9 +16,9 @@ struct IntroPage: Identifiable {
 
 struct IntroPagesModel {
     static let pages: [IntroPage] = [
-        IntroPage(title: "Welcome", description: "Manage your school tasks easily.", systemImage: "star"),
-        IntroPage(title: "Track Progress", description: "Keep track of what you've learned.", systemImage: "list.bullet.rectangle"),
-        IntroPage(title: "Stay Focused", description: "Use timers to stay productive.", systemImage: "timer")
+        IntroPage(title: "Welcome", description: "School Assistant helps you learn anything faster and have fun doing it.", systemImage: "books.vertical"),
+        IntroPage(title: "Democratize Learning", description: "Our goal is to democratize knowledge and make studying simpler for everyone.", systemImage: "bolt.fill"),
+        IntroPage(title: "Disclaimer", description: "An app can't replace a real teacher but it will help you learn with ease.", systemImage: "exclamationmark.triangle")
     ]
 }
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ SchoolAssisstant is a study companion app built with SwiftUI. It helps students 
 ## Features
 - **Pomodoro Timer** – Focused study sessions with optional relaxation break.
 - **Learning Notes** – Save quick notes while studying and review them later.
-- **Revision Reminders** – View due notes using a spaced-repetition approach.
+- **Revision Reminders** – View due notes using a spaced-repetition approach and receive notifications to review new information.
+- **Disclaimer** – School Assistant cannot replace a real teacher but helps you learn with ease.
 - **Statistics** – Charts showing daily study minutes.
 - **Profile Management** – Sign up, log in, and edit your account details.
+- **Study State Prompt** – After logging in, specify whether you're in middle school, high school, college, or another level.
 - **Tasks** – Keep track of homework and receive reminders.
 - **Streaks & Friends** – View your study streak and nudge friends to join you.
 

--- a/SchoolAssisstant.xcodeproj/project.pbxproj
+++ b/SchoolAssisstant.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		E37B3C592DA8411B005CB93F /* ShowEmailAdressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E37B3C562DA8411B005CB93F /* ShowEmailAdressView.swift */; };
 		E37B3C5B2DA8418B005CB93F /* ModifyBiographyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E37B3C5A2DA8418B005CB93F /* ModifyBiographyView.swift */; };
 		E37B3C5F2DA843A0005CB93F /* ResetPasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E37B3C5E2DA843A0005CB93F /* ResetPasswordView.swift */; };
+                3dda1ecaa1b03555ea42b8f0 /* StudyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = d5a000bea56848f4bae60b46 /* StudyStateView.swift */; }
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -71,6 +72,7 @@
 		E37B3C572DA8411B005CB93F /* ShowPasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowPasswordView.swift; sourceTree = "<group>"; };
 		E37B3C5A2DA8418B005CB93F /* ModifyBiographyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyBiographyView.swift; sourceTree = "<group>"; };
 		E37B3C5E2DA843A0005CB93F /* ResetPasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPasswordView.swift; sourceTree = "<group>"; };
+                d5a000bea56848f4bae60b46 /* StudyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyStateView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -245,6 +247,7 @@
 			isa = PBXGroup;
 			children = (
 				E3405EFF2DA80F4100216E57 /* HomeTab.swift */,
+                                d5a000bea56848f4bae60b46 /* StudyStateView.swift */,
 			);
 			path = HomeView;
 			sourceTree = "<group>";
@@ -344,6 +347,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E3405F162DA80F4200216E57 /* HomeTab.swift in Sources */,
+                                3dda1ecaa1b03555ea42b8f0 /* StudyStateView.swift in Sources */,
 				E3405F172DA80F4200216E57 /* SignUpEmailViewModel.swift in Sources */,
 				E37B3C5F2DA843A0005CB93F /* ResetPasswordView.swift in Sources */,
 				E37B3C582DA8411B005CB93F /* ShowPasswordView.swift in Sources */,

--- a/StudyStateView.swift
+++ b/StudyStateView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct StudyStateView: View {
+    @Binding var show: Bool
+    @State private var studyState: String = "Middle School"
+    private let studyOptions = ["Middle School", "High School", "College", "University", "Other"]
+    @StateObject private var viewModel = userManagerViewModel()
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Text("Where do you study?")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+
+                Picker("Study State", selection: $studyState) {
+                    ForEach(studyOptions, id: \.self) { option in
+                        Text(option).tag(option)
+                    }
+                }
+                .pickerStyle(.wheel)
+
+                Button("Save") {
+                    Task {
+                        try? await viewModel.updateStudyState(state: studyState)
+                        show = false
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
+            .onAppear {
+                Task { try? await viewModel.loadCurrentUser() }
+            }
+        }
+    }
+}
+
+#Preview {
+    StudyStateView(show: .constant(true))
+}

--- a/UserInfosCreation.swift
+++ b/UserInfosCreation.swift
@@ -25,6 +25,8 @@ struct UserInfosCreation: View {
     
     @StateObject private var viewModel = userManagerViewModel()
     @State private var profileImageData: Data? = nil
+    @State private var studyState: String = "Middle School"
+    private let studyOptions = ["Middle School", "High School", "College", "University", "Other"]
     
     @FocusState private var focusedField: Field?
     
@@ -69,6 +71,20 @@ struct UserInfosCreation: View {
                         .datePickerStyle(CompactDatePickerStyle())
                         .cardStyle()
                         .padding(.horizontal)
+
+                    // Study State
+                    VStack(alignment: .leading) {
+                        Text("Study State")
+                            .font(.headline)
+                        Picker("Study State", selection: $studyState) {
+                            ForEach(studyOptions, id: \.self) { option in
+                                Text(option).tag(option)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                    }
+                    .cardStyle()
+                    .padding(.horizontal)
                     
                     
                     // Profile Image Picker
@@ -188,6 +204,8 @@ struct UserInfosCreation: View {
                 birthDate: birthDate,
                 username: username,
             )
+
+            try await UserManager.shared.updateStudyState(userId: userId, studyState: studyState)
             
             
             print("Informations registred successfully")

--- a/UserManager.swift
+++ b/UserManager.swift
@@ -24,6 +24,7 @@ struct DBUser: Codable {
     let lastName: String?
     let profileImagePathUrl: String?
     let biography: String?
+    let studyState: String?
     var fcmToken: String?
     
     // MARK: - Initializers
@@ -37,6 +38,7 @@ struct DBUser: Codable {
         self.username = nil
         self.profileImagePathUrl = nil
         self.biography = nil
+        self.studyState = nil
         self.fcmToken = nil
     }
     
@@ -50,6 +52,7 @@ struct DBUser: Codable {
         lastName: String? = nil,
         profileImagePathUrl: String? = nil,
         biography: String? = nil,
+        studyState: String? = nil,
         fcmToken: String? = nil
     ) {
         self.userId = userId
@@ -60,6 +63,7 @@ struct DBUser: Codable {
         self.username = username
         self.profileImagePathUrl = profileImagePathUrl
         self.biography = biography
+        self.studyState = studyState
         self.fcmToken = fcmToken
     }
     
@@ -74,6 +78,7 @@ struct DBUser: Codable {
         case lastName = "last_name"
         case profileImagePathUrl = "profile_image_path_url"
         case biography = "biography"
+        case studyState = "study_state"
         case fcmToken = "fcmToken" // Coding Key for FCM Token
     }
     
@@ -89,6 +94,7 @@ struct DBUser: Codable {
         self.username = try container.decodeIfPresent(String.self, forKey: .username)
         self.profileImagePathUrl = try container.decodeIfPresent(String.self, forKey: .profileImagePathUrl)
         self.biography = try container.decodeIfPresent(String.self, forKey: .biography)
+        self.studyState = try container.decodeIfPresent(String.self, forKey: .studyState)
         self.fcmToken = try container.decodeIfPresent(String.self, forKey: .fcmToken) // Decode FCM Token
     }
     
@@ -104,6 +110,7 @@ struct DBUser: Codable {
         try container.encodeIfPresent(self.age, forKey: .age)
         try container.encodeIfPresent(self.profileImagePathUrl, forKey: .profileImagePathUrl)
         try container.encodeIfPresent(self.biography, forKey: .biography)
+        try container.encodeIfPresent(self.studyState, forKey: .studyState)
         try container.encodeIfPresent(self.fcmToken, forKey: .fcmToken) // Encode FCM Token
     }
 
@@ -116,6 +123,7 @@ struct DBUser: Codable {
         self.lastName = data[CodingKeys.lastName.rawValue] as? String
         self.profileImagePathUrl = data[CodingKeys.profileImagePathUrl.rawValue] as? String
         self.biography = data[CodingKeys.biography.rawValue] as? String
+        self.studyState = data[CodingKeys.studyState.rawValue] as? String
         self.fcmToken = data[CodingKeys.fcmToken.rawValue] as? String
     }
 
@@ -130,6 +138,7 @@ struct DBUser: Codable {
         if let lastName = lastName { dict[CodingKeys.lastName.rawValue] = lastName }
         if let profileImagePathUrl = profileImagePathUrl { dict[CodingKeys.profileImagePathUrl.rawValue] = profileImagePathUrl }
         if let biography = biography { dict[CodingKeys.biography.rawValue] = biography }
+        if let studyState = studyState { dict[CodingKeys.studyState.rawValue] = studyState }
         if let fcmToken = fcmToken { dict[CodingKeys.fcmToken.rawValue] = fcmToken }
         return dict
     }
@@ -205,6 +214,10 @@ final class UserManager: ObservableObject {
 
     func updateUsername(userId: String, username: String) async throws {
         try await userDocument(userId: userId).setData(["username": username], merge: true)
+    }
+
+    func updateStudyState(userId: String, studyState: String) async throws {
+        try await userDocument(userId: userId).setData(["study_state": studyState], merge: true)
     }
     
     func addStudySessionRegisteredToUser(userId: String, studiedSubject: String, start: Date, end: Date) async throws {
@@ -353,6 +366,12 @@ final class userManagerViewModel: ObservableObject {
         print("Name: \(name)")
         let url = try await StorageManager.shared.getUrlForImage(path: path)
         try await UserManager.shared.updateUserProfileImagePathUrl(userId: userId, path: path, url: url.absoluteString)
+    }
+
+    func updateStudyState(state: String) async throws {
+        guard let userId = Auth.auth().currentUser?.uid else { return }
+        try await UserManager.shared.updateStudyState(userId: userId, studyState: state)
+        try await loadCurrentUser()
     }
     
     func deleteProfileImage() {

--- a/UserWantsToAddInfoView.swift
+++ b/UserWantsToAddInfoView.swift
@@ -95,6 +95,11 @@ struct UserWantsToAddInfoView: View {
 
         do {
             try await NotesManager.shared.addNote(note, userId: userId)
+            let now = Date()
+            NotificationManager.scheduleNotification(title: "Review", body: learned, at: Calendar.current.date(byAdding: .hour, value: 1, to: now) ?? now)
+            NotificationManager.scheduleNotification(title: "Review", body: learned, at: Calendar.current.date(byAdding: .day, value: 1, to: now) ?? now)
+            NotificationManager.scheduleNotification(title: "Review", body: learned, at: Calendar.current.date(byAdding: .day, value: 4, to: now) ?? now)
+            NotificationManager.scheduleNotification(title: "Review", body: learned, at: Calendar.current.date(byAdding: .day, value: 7, to: now) ?? now)
             userWantsAddInfo = false
         } catch {
             print("Failed to save note: \(error)")


### PR DESCRIPTION
## Summary
- enhance intro pages with new messaging
- prompt for study state when account lacks this info
- allow setting study state at registration and from a dedicated view
- schedule review notifications when adding a learning note
- update documentation and include new file in project

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6846d7f57c6c832ab6e3fbf2f6a226c5