### PR TITLE
Enhance social features and reminders

### DIFF
--- a/SchoolAssisstant/Managers/NotificationManager.swift
+++ b/SchoolAssisstant/Managers/NotificationManager.swift
@@ -16,4 +16,9 @@ enum NotificationManager {
                                             trigger: trigger)
         center.add(request)
     }
+
+    static func cancelAll() {
+        let center = UNUserNotificationCenter.current()
+        center.removeAllPendingNotificationRequests()
+    }
 }

--- a/SchoolAssisstant/Views/SchoolAssisstantApp.swift
+++ b/SchoolAssisstant/Views/SchoolAssisstantApp.swift
@@ -62,9 +62,9 @@ struct MainInterfaceView: View {
                     .tabItem { Label("Study", systemImage: "pencil.and.outline") }
                     .tag(Tab.studySession)
 
-                StatsView()
-                    .tabItem { Label("Stats", systemImage: "chart.bar") }
-                    .tag(Tab.stats)
+                SocialView()
+                    .tabItem { Label("Social", systemImage: "person.2.fill") }
+                    .tag(Tab.social)
 
 //                TasksTab()
 //                    .tabItem { Label("Tasks", systemImage: "list.bullet") }
@@ -91,7 +91,7 @@ enum Tab {
     case home
     case account
     case studySession
-    case stats
+    case social
     case learnedSomething
     case tasks
 }

--- a/SchoolAssisstant/Views/SocialPage/SocialView.swift
+++ b/SchoolAssisstant/Views/SocialPage/SocialView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct SocialView: View {
+    @StateObject private var viewModel = userManagerViewModel()
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(viewModel.leaderboard, id: \.userId) { friend in
+                    if friend.userId != viewModel.user?.userId {
+                        VStack(alignment: .leading) {
+                            Text(friend.username ?? "Unknown")
+                                .font(.headline)
+                            if let last = friend.lastConnection {
+                                Text("Last online: \(last, style: .relative)")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Social")
+            .onAppear {
+                Task {
+                    try? await viewModel.loadCurrentUser()
+                    await viewModel.loadLeaderboard()
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SocialView()
+}

--- a/Tests/SchoolAssisstantPackageTests/PlaceholderTests.swift
+++ b/Tests/SchoolAssisstantPackageTests/PlaceholderTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import SchoolAssisstantPackage
+
+final class PlaceholderTests: XCTestCase {
+    func testExample() {
+        XCTAssertTrue(true)
+    }
+}


### PR DESCRIPTION
## Summary
- record and store last connection time for each user
- add daily login reminder at 8pm
- move statistics chart onto home tab
- display friends' last online status
- introduce Social page and replace Stats tab
- add placeholder unit tests so the package builds

## Testing
- `swift build`

------
https://chatgpt.com/codex/tasks/task_e_68470cb34840832a9d0c70a3d912574a