### PR TITLE
Add Xcode workspace for easier project opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ SchoolAssisstant is a study companion app built with SwiftUI. It helps students 
 
 ## Setup
 1. Install Xcode 15 or later (requires iOS 16+).
-2. Clone this repository and open `SchoolAssisstant.xcodeproj`.
+2. Clone this repository and open `SchoolAssisstant.xcworkspace`.
+   If Xcode tries to open the folder as a Swift package, choosing the
+   workspace ensures the app project is loaded.
 3. Add your Firebase `GoogleService-Info.plist` to enable authentication and storage.
 4. Build and run on a simulator or device.
 

--- a/SchoolAssisstant.xcworkspace/contents.xcworkspacedata
+++ b/SchoolAssisstant.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:SchoolAssisstant.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
## Summary
- add a root Xcode workspace that references the existing project
- update setup instructions to open the workspace to avoid Xcode opening the repo as a package

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68471080b114832a8445b2660ef5c498